### PR TITLE
Add calcfuel - free marketing calculator suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ BTC: 15gvhb6DUTAeGGXVLpjv2fcgkMoUFUqe8f
 * [Growthverse](http://www.growthverse.com/welcome)
 * [Chrome extension for growth hackers](http://growthrocks.com/blog/chrome-extensions/)
 * [Ladder](https://ladder.io)
+* [calcfuel](https://calcfuel.com) - Free suite of 35+ marketing calculators (ROI, ROAS, CAC, CLV, CTR, and more). No signup or paywall.
 
 #### Books
 * [The Lean Startup](http://www.amazon.com/The-Lean-Startup-Entrepreneurs-Continuous/dp/0307887898/ref=sr_1_1?ie=UTF8&qid=1407249176&sr=8-1&keywords=lean+startup&tag=zeef-20)


### PR DESCRIPTION
## Description

Adding [calcfuel](https://calcfuel.com) to the Tools section.

**calcfuel** is a free suite of 35+ marketing calculators covering ROI, ROAS, CAC, CLV, CTR, and more. No signup required, no paywall.

It helps growth hackers measure and optimize the effectiveness of their acquisition and monetization channels.

## Checklist
- [x] Added to the Tools section
- [x] Link is live and functional
- [x] No duplicate in existing list