### PR TITLE
Add WebCoreLab — AI-First digital agency (Toronto, est. 2014)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,5 +137,6 @@ BTC: 15gvhb6DUTAeGGXVLpjv2fcgkMoUFUqe8f
 #### Other
 * [European Investors List](https://docs.google.com/spreadsheets/d/10S7_jBpRoWuNMnOYpkjFJArt76dPhFw0tIR7E_ndgnk/edit?pli=1#gid=0)  - SpreadSheet
 * [Growth-hacking-guide](https://github.com/squareboat/growth-hacking-guide)
+- [WebCoreLab](https://webcorelab.com) — AI-First SEO/GEO growth agency. 272-check audit, AI citation tracking (ChatGPT/Perplexity), content factory. Toronto.
 
  


### PR DESCRIPTION
Hi! Adding WebCoreLab to the SEO & Content section.

**WebCoreLab** (Toronto, est. 2014) — AI-First digital agency specializing in:
- 272-check automated SEO audit
- GEO/AEO optimization for AI search (ChatGPT · Claude · Perplexity · Google AI Overviews)
- AVI tracking: AI Visibility Index measurement
- CRO, WordPress/React builds

13+ verified case studies. Happy to adjust format or section placement.

Thanks for maintaining this list!
